### PR TITLE
Update the README to provide more specific and detailed instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,30 @@ This is the Glitch equivalent of running `create-probot-app` to generate a new p
 
 To get your own Glitch-hosted Probot up-and-running:
 
-1. Head on back to our [Devlopment Docs](https://probot.github.io/docs/development/#configuring-a-github-app) to configure your GitHub App.
 
-2. Click the **New File** button (at left on Glitch) and type `.data/private-key.pem`. Then click **Add File**. Open the private key you downloaded during your Github App creation, and copy/paste the contents into your new file.
+1. [Configure a new app on Github](https://github.com/settings/apps/new).
+    - Hit the "Show" button on the top left of this page to find the URL. It will look something like `https://random-word.glitch.me/probot`, except the domain will be specific to your app.
+    - For the Homepage URL, use your app URL that you just found (updating the domain to match yours): `https://random-word.glitch.me/probot`
+    - For the Webhook URL, use this URL (again, updating the domain to match yours): `https://random-word.glitch.me/`. Notice that we left off the `/probot`.
+    - For the Webhook Secret, open a terminal and run `openssl rand -base64 32`. Copy/paste the outputted value to the Webhook Secret box. Keep this handy
+    until Step 4.
+    - Choose the permissions you want to give your bot based on what you want to build (ex. issues bot, PR bot, hybrid).
+    - Save your changes.
+    - On the configuration page that comes up after saving, download your private key. It will be saved into a file named `my-app-name.2018-06-20.private-key.pem`, with your app name, and today's date.
 
-3. Edit the `.env` file (at left) with your app credentials. 
+2. Click the **Install** tab, and install your app into one of your repositories.
+
+3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Open a terminal, and from your download folder run `cat my-app-name.2018-06-20.private-key.pem | pbcopy` (except using your app's name and today's date). In the new file in Glitch, paste the contents of the clipboard.
+
+4. Edit the `.env` file (at left) with your app credentials. 
     - `APP_ID` can be found in the About section of your Github app.
     - `WEBHOOK_SECRET` is the value you generated in Step 2.
     - `PRIVATE_KEY_PATH=` should be set to `.data/private-key.pem`. 
     - `NODE_ENV=` should be set to `production`. 
 
-4. Wait for app to load. A green `Live` label should show up next to the **Show** button when it's finished loading.
+5. Wait for app to load. A green `Live` label should show up next to the **Show** button when it's finished loading.
+
+6. Open a new issue in the repo where you installed your app, and watch for your app to reply!
 
 5. Head back to our [Webhook Docs](https://probot.github.io/docs/webhooks/) to learn how to start building your app.
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 1. [Configure a new app on Github](https://github.com/settings/apps/new).
     - Hit the "Show" button on the top left of this page to find the URL. It will look something like `https://random-word.glitch.me/probot`, except the domain will be specific to your app.
     - For the Webhook URL, use this URL (again, updating the domain to match yours): `https://random-word.glitch.me/`. Notice that we left off the `/probot`.
-    - For the Webhook Secret, juse use "development".
+    - For the Webhook Secret, just use "development".
     until Step 4.
     - Save your changes.
     - On the **Permissions & webhooks** tab, add read and write permissions for issues.

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ This is the Glitch equivalent of running `create-probot-app` to generate a new p
 
 ## Getting Started
 
-To get your own Glitch-hosted Probot up-and-running:
-
+To get your own Glitch-hosted Probot up-and-running, follow these steps. If you need more detail, the [Probot Docs](https://probot.github.io/docs/development/#configuring-a-github-app) are a great place to go to learn more.
 
 1. [Configure a new app on Github](https://github.com/settings/apps/new).
     - Hit the "Show" button on the top left of this page to find the URL. It will look something like `https://random-word.glitch.me/probot`, except the domain will be specific to your app.
-    - For the Homepage URL, use your app URL that you just found (updating the domain to match yours): `https://random-word.glitch.me/probot`
     - For the Webhook URL, use this URL (again, updating the domain to match yours): `https://random-word.glitch.me/`. Notice that we left off the `/probot`.
-    - For the Webhook Secret, open a terminal and run `openssl rand -base64 32`. Copy/paste the outputted value to the Webhook Secret box. Keep this handy
+    - For the Webhook Secret, juse use "development".
     until Step 4.
-    - Choose the permissions you want to give your bot based on what you want to build (ex. issues bot, PR bot, hybrid).
+    - Save your changes.
+    - On the **Permissions & webhooks** tab, add read and write permissions for issues.
+    - On the **Permissions & webhooks** tab, subscribe to **Issues** events.
     - Save your changes.
     - On the configuration page that comes up after saving, download your private key. It will be saved into a file named `my-app-name.2018-06-20.private-key.pem`, with your app name, and today's date.
 


### PR DESCRIPTION
I think there is some value in maintaining Glitch-specific instructions in the Glitch README. In particular, the Glitch instructions should at a minimum indicate what URLs/endpoints to use in the various fields in the app registration page (as this was _very_ non-obvious to me, building a Probot on Glitch for the first time).

I've also included some instructions for how to get the contents of the private key into the clipboard, since simply opening the file by double-clicking on it will open it in Keychain.app, which will not reveal the raw contents of the file.

Feedback is very welcome!