### PR TITLE
Update the readme in the face of experience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,24 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. Bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `, do the following:
 
     Mac:
-    ```bash
+```bash
 pbcopy < ~/.ssh/id_rsa.pub
 # Copies the contents of the id_rsa.pub file to your clipboard
-    ```
+```
 
     Windows:
-    ```
+```
 clip < ~/.ssh/id_rsa.pub
 # Copies the contents of the id_rsa.pub file to your clipboard
-    ```
+```
     
     Linux:
-    ```bash
+```bash
 sudo apt-get install xclip
 # Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)
 xclip -sel clip < ~/.ssh/id_rsa.pub
 # Copies the contents of the id_rsa.pub file to your clipboard
-    ```
+```
 
    In the new file in Glitch, paste the contents of the clipboard.
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,23 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. Bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `, do the following:
 
-Mac:
+  * Mac:
 ```bash
-pbcopy < ~/.ssh/id_rsa.pub
+pbcopy < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-Windows:
+  * Windows:
 ```
-clip < ~/.ssh/id_rsa.pub
+clip < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-Linux:
+  * Linux:
 ```bash
 sudo apt-get install xclip
 # Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)
-xclip -sel clip < ~/.ssh/id_rsa.pub
+xclip -sel clip < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
     - `APP_ID` can be found in the About section of your Github app.
     - `WEBHOOK_SECRET` is the value you generated in Step 2.
     - `PRIVATE_KEY_PATH=` should be set to `.data/private-key.pem`. 
-    - `NODE_ENV=` should be set to `Production`. 
+    - `NODE_ENV=` should be set to `production`. 
 
 5. Wait for app to load. A green `Live` label should show up next to the **Show** button when it's finished loading.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This is the Glitch equivalent of running `create-probot-app` to generate a new p
 
 To get your own Glitch-hosted Probot up-and-running, follow these steps. If you need more detail, the [Probot Docs](https://probot.github.io/docs/development/#configuring-a-github-app) are a great place to go to learn more.
 
-1. [Configure a new app on Github](https://github.com/settings/apps/new).
-    - Hit the "Show" button on the top left of this page to find the URL. It will look something like `https://random-word.glitch.me/probot`, except the domain will be specific to your app.
-    - For the Authentication URL and the Webhook URL, use this URL (again, updating the domain to match yours): `https://random-word.glitch.me/`. Notice that we left off the `/probot`.
+1. [Configure a new app on Github](https://github.com/settings/apps), and click "New GitHub App". You might want to do this in a new window, because we will be copying-and-pasting information back and forth.
+    - Hit the "Share" button on the top left of this page, and find "Share your App" to find the URL to your App. It will look something like `https://random-word.glitch.me/`, except the domain will be specific to your app's name.
+    - For the Authentication URL and the Webhook URL, use this URL (again, updating the domain to match yours): `https://random-word.glitch.me/`.
     - For the Webhook Secret, just use "development".
     until Step 4.
     - On the **Permissions & webhooks** tab, add read and write permissions for issues.
@@ -21,13 +21,13 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 2. Click the **Install** tab, and install your app into one of your repositories.
 
-3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Open a terminal, and from your download folder run `cat my-app-name.2018-06-20.private-key.pem | pbcopy` (except using your app's name and today's date). In the new file in Glitch, paste the contents of the clipboard.
+3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. You can [follow the directions here](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) to find out how to do that on your system, bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `. In the new file in Glitch, paste the contents of the clipboard.
 
 4. Edit the `.env` file (at left) with your app credentials. 
     - `APP_ID` can be found in the About section of your Github app.
     - `WEBHOOK_SECRET` is the value you generated in Step 2.
     - `PRIVATE_KEY_PATH=` should be set to `.data/private-key.pem`. 
-    - `NODE_ENV=` should be set to `production`. 
+    - `NODE_ENV=` should be set to `Production`. 
 
 5. Wait for app to load. A green `Live` label should show up next to the **Show** button when it's finished loading.
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. Bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `, do the following:
 
-    Mac:
+Mac:
 ```bash
 pbcopy < ~/.ssh/id_rsa.pub
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-    Windows:
+Windows:
 ```
 clip < ~/.ssh/id_rsa.pub
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
-    
-    Linux:
+
+Linux:
 ```bash
 sudo apt-get install xclip
 # Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,29 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 2. Click the **Install** tab, and install your app into one of your repositories.
 
-3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. You can [follow the directions here](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) to find out how to do that on your system, bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `. In the new file in Glitch, paste the contents of the clipboard.
+3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. Bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `, do the following:
+
+    Mac:
+    ```bash
+pbcopy < ~/.ssh/id_rsa.pub
+# Copies the contents of the id_rsa.pub file to your clipboard
+    ```
+
+    Windows:
+    ```
+clip < ~/.ssh/id_rsa.pub
+# Copies the contents of the id_rsa.pub file to your clipboard
+    ```
+    
+    Linux:
+    ```bash
+sudo apt-get install xclip
+# Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)
+xclip -sel clip < ~/.ssh/id_rsa.pub
+# Copies the contents of the id_rsa.pub file to your clipboard
+    ```
+
+   In the new file in Glitch, paste the contents of the clipboard.
 
 4. Edit the `.env` file (at left) with your app credentials. 
     - `APP_ID` can be found in the About section of your Github app.

--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. Bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `, do the following:
 
-    - Mac:
+  * Mac:
 ```bash
 pbcopy < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-    - Windows:
+  * Windows:
 ```
 clip < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-    - Linux:
+  * Linux:
 ```bash
 sudo apt-get install xclip
 # Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)

--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 3. Click the **New File** button (at left) and type `.data/private-key.pem`. Then click **Add File**. Now we need to copy the key to the clipboard. Bearing in mind that your private key is in your Downloads folder, and will be named like `my-app-name.2018-06-20.private-key.pem `, do the following:
 
-  * Mac:
+    - Mac:
 ```bash
 pbcopy < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-  * Windows:
+    - Windows:
 ```
 clip < ~/path/to/downloads/app-name.private-key.pem
 # Copies the contents of the id_rsa.pub file to your clipboard
 ```
 
-  * Linux:
+    - Linux:
 ```bash
 sudo apt-get install xclip
 # Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)


### PR DESCRIPTION
You might be wondering about the change to the new app link. It's a funny story. We used that link just now, and although it took us to the right place no problem, clicking "save" resulted in an infinite loop! It brought us rivght back to the same app registration page and there was no way to break out. But going to /settings/apps, and clicking the new app button avoided that situation. So. There.