### PR TITLE
Corrected Github to GitHub, removed mention of Fog Creek

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ To get your own Glitch-hosted Probot up-and-running, follow these steps. If you 
 
 ## Get Started with Probot on Glitch
 1. When you [Remix](https://glitch.com/help/remix/) an app on Glitch you get your own **🤖Glitch Probot App**. 
-2. The next step is to create a **😸Github App**. Probot now has a handy button that does this for you automatically! Click the **Glitch 🕶 Show** button. In the [editor](https://glitch.com/edit) it's right up top to the left. 
-3. It will take you to your **🐠Glitch app URL** + `/probot`. And you'll see a button that says "Register Github App." Click it and it will take you to **Github** where you'll create a unique name for your **😸Github App** like "Worlds Coolest Probot"
-4. It will guide you through the steps, you'll want to install your new **😸Github App** to at least one repository if you want to try it out. 
+2. The next step is to create a **😸GitHub App**. Probot now has a handy button that does this for you automatically! Click the **Glitch 🕶 Show** button. In the [editor](https://glitch.com/edit) it's right up top to the left. 
+3. It will take you to your **🐠Glitch app URL** + `/probot`. And you'll see a button that says "Register GitHub App." Click it and it will take you to **GitHub** where you'll create a unique name for your **😸GitHub App** like "Worlds Coolest Probot"
+4. It will guide you through the steps, you'll want to install your new **😸GitHub App** to at least one repository if you want to try it out. 
 5. Open a new issue in the repository where you installed your app, and watch for your **🤖Glitch Probot App** to reply!
 
 That's it! Head back to the Probot [Webhook Docs](https://probot.github.io/docs/webhooks/) to learn how to start building out your **🤖Glitch Probot App**. 
@@ -18,13 +18,11 @@ That's it! Head back to the Probot [Webhook Docs](https://probot.github.io/docs/
 ## Glossary 
 - **🤖Glitch Probot App**: Your Probot, hosted on Glitch
 - **🐠Glitch app URL**: the URL of your Glitch Probot app
-- **😸Github App**: A Github App that your **🤖Glitch Probot App** uses to commicate with Github.
+- **😸GitHub App**: A GitHub App that your **🤖Glitch Probot App** uses to commicate with GitHub.
       
 #### About Glitch
 
 **Glitch** is the friendly commmunity where you'll build the app of your dreams. Glitch lets you instantly create, remix, edit, and host an app, bot or site, and you can invite collaborators or helpers to simultaneously edit code with you.
 
 Find out more [about Glitch](https://glitch.com/about).
-
-Glitch is made by [Fog Creek](https://fogcreek.com/)
 \ ゜o゜)ノ


### PR DESCRIPTION
Realized when writing the blog post that it should be GitHub 
https://github.com/probot/twitter/pull/7

Also that Fog Creek is now just Glitch.

-----
[View rendered README.md](https://github.com/melissamcewen/hello-world/blob/github-glitch/README.md)